### PR TITLE
update utils and netconf unit tests

### DIFF
--- a/pkg/netconf/netconf_test.go
+++ b/pkg/netconf/netconf_test.go
@@ -1796,7 +1796,7 @@ func fakeSendSetupHostInterfaceErr(request *proto.SetupHostInterfaceRequest) err
 }
 
 func fakeGrpcDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	return grpc.DialContext(context.TODO(), "", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	return grpc.DialContext(context.TODO(), "foo.bar:54321", grpc.WithTransportCredentials(insecure.NewCredentials()))
 }
 
 func fakeGrpcDialErr(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1056,7 +1056,7 @@ func (fs *FakeFilesystem) Use(tmpDir string) (string, func(), error) {
 }
 
 func fakeGrpcDial(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
-	return grpc.DialContext(context.TODO(), "", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	return grpc.DialContext(context.TODO(), "foo.bar:54321", grpc.WithTransportCredentials(insecure.NewCredentials()))
 }
 
 func fakeGrpcDialErr(target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {


### PR DESCRIPTION
updated pkg/utils and pkg/netconf unit test which was broken after grpc package version upgrade.
Tested locally with go v1.19.4

Signed-off-by: Abdul Halim <abdul.halim@intel.com>