### PR TITLE
Fixed infraagent failure in insecure mode

### DIFF
--- a/deploy/infraagent-daemonset.yaml
+++ b/deploy/infraagent-daemonset.yaml
@@ -54,6 +54,8 @@ spec:
         volumeMounts:
         - name: client-certs
           mountPath: /tmp/infraagent/cert/client/
+        - name: config-volume
+          mountPath: /etc/infra/
       containers:
       - name: agent
         image: infraagent:latest

--- a/pkg/inframanager/store/storeendpoint.go
+++ b/pkg/inframanager/store/storeendpoint.go
@@ -50,7 +50,7 @@ func InitEndPointStore(setFwdPipe bool) bool {
 	}
 
 	if _, err := os.Stat(storePath); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(storePath, 0640)
+		err := os.MkdirAll(storePath, 0640)
 		if err != nil {
 			log.Error("Failed to create directory ", storePath)
 			return false

--- a/pkg/inframanager/store/storepolicy.go
+++ b/pkg/inframanager/store/storepolicy.go
@@ -85,7 +85,7 @@ func InitPolicyStore(setFwdPipe bool) bool {
 	}
 
 	if _, err := os.Stat(storePath); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(storePath, 0640)
+		err := os.MkdirAll(storePath, 0640)
 		if err != nil {
 			log.Error("Failed to create directory ", storePath)
 			return false

--- a/pkg/inframanager/store/storeservice.go
+++ b/pkg/inframanager/store/storeservice.go
@@ -51,7 +51,7 @@ func InitServiceStore(setFwdPipe bool) bool {
 	}
 
 	if _, err := os.Stat(storePath); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(storePath, 0640)
+		err := os.MkdirAll(storePath, 0640)
 		if err != nil {
 			log.Error("Failed to create directory ", storePath)
 			return false


### PR DESCRIPTION
In insecure mode, the infraagent's wait pod fails to connect and check the manager's grpc server. The changes will fix the issue.