### PR TITLE
Read manager config from configmap.

### DIFF
--- a/deploy/inframanager-daemonset.yaml
+++ b/deploy/inframanager-daemonset.yaml
@@ -38,6 +38,8 @@ spec:
         volumeMounts:
         - name: db
           mountPath: /var/lib/cni/inframanager
+        - name: config-volume
+          mountPath: /etc/infra/
         - name: client-certs
           mountPath: /etc/pki/inframanager/certs/client
         - name: server-certs
@@ -54,6 +56,9 @@ spec:
         hostPath:
           path: /var/lib/cni/inframanager
           type: DirectoryOrCreate
+      - name: config-volume
+        configMap:
+          name: inframanager-config
       - name: client-certs
         secret:
           secretName: manager-client-secret

--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -10,6 +10,11 @@ resources:
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+configMapGenerator:
+- files:
+  - ../inframanager/config.yaml
+  name: inframanager-config
+  namespace: kube-system
 images:
 - name: infraagent:latest
 - name: inframanager:latest

--- a/images/Dockerfile.manager
+++ b/images/Dockerfile.manager
@@ -27,6 +27,5 @@ FROM alpine:3.16
 WORKDIR /
 RUN mkdir -p /etc/infra /share/infra/k8s_dp
 COPY --from=builder /workspace/bin/inframanager /inframanager
-COPY --from=builder /workspace/inframanager/config.yaml /etc/infra/config.yaml
 COPY --from=builder /workspace/k8s_dp /share/infra/k8s_dp/
 ENTRYPOINT ["/inframanager"]


### PR DESCRIPTION
Till now, the manager configuration file is manually copied into the docker image during the image creation. Change it to dynamically read the fields via config map. This way, no need to rebuild the manager's docker image for every change in the configuration.