### PR TITLE
Fix for "no cdq resources available"

### DIFF
--- a/pkg/cni/cni.go
+++ b/pkg/cni/cni.go
@@ -207,12 +207,6 @@ func (s *CniServer) Del(ctx context.Context, in *pb.DelRequest) (*pb.DelReply, e
 		out.ErrorMessage = err.Error()
 		return out, nil
 	}
-	c := newInfraAgentClient(conn)
-	out, err = s.podInterface.ReleaseNetwork(ctx, c, in)
-	if err != nil || !out.Successful {
-		s.log.WithError(err).Error("Failed to clean up interface config via infra-manager")
-		return out, err
-	}
 
 	err = s.podInterface.ReleasePodInterface(in)
 	if err != nil {
@@ -220,6 +214,17 @@ func (s *CniServer) Del(ctx context.Context, in *pb.DelRequest) (*pb.DelReply, e
 		out.Successful = false
 		return out, nil
 	}
+
+	c := newInfraAgentClient(conn)
+	out, err = s.podInterface.ReleaseNetwork(ctx, c, in)
+	if err != nil || !out.Successful {
+		s.log.WithError(err).Error("Failed to clean up interface config via infra-manager")
+		return out, err
+	}
+	if s.podInterfaceType != types.IpvlanPodInterface {
+		netconf.DeletePodIfaceConf(in.InterfaceName, s.podInterfaceType, in.Netns)
+	}
+
 	return out, nil
 }
 

--- a/pkg/netconf/cdq.go
+++ b/pkg/netconf/cdq.go
@@ -171,9 +171,6 @@ func (pi *cdqIntfHandler) ReleasePodInterface(in *pb.DelRequest) error {
 	}
 
 	pi.pool.Release(conf.InterfaceName)
-	// remove cache, ignore error
-	path := filepath.Join(utilsGetDataDirPath(types.CDQInterface), refid+"-"+in.InterfaceName)
-	_ = os.Remove(path)
 	return nil
 }
 

--- a/pkg/netconf/netutils.go
+++ b/pkg/netconf/netutils.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
+	"path/filepath"
 
 	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -69,6 +71,13 @@ func (e nsError) Error() string { return e.msg }
 
 func newNsError(toWrap error) nsError {
 	return nsError{msg: fmt.Sprintf("Error in containers namespace: %s", toWrap.Error())}
+}
+
+func DeletePodIfaceConf(ifaceName, ifaceType, netNS string) {
+	refid := filepath.Base(netNS)
+	// remove cache, ignore error
+	path := filepath.Join(utilsGetDataDirPath(ifaceType), refid+"-"+ifaceName)
+	_ = os.Remove(path)
 }
 
 func setupContainerRoutes(link netlink.Link, gw net.IP, containerRoutes []string) error {

--- a/pkg/netconf/sriovpodinterface.go
+++ b/pkg/netconf/sriovpodinterface.go
@@ -17,7 +17,6 @@ package netconf
 import (
 	"context"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/containernetworking/plugins/pkg/ipam"
@@ -202,9 +201,6 @@ func (pi *sriovPodInterface) ReleasePodInterface(in *pb.DelRequest) error {
 		return err
 	}
 	pi.pool.Release(conf.InterfaceName)
-	// remove cache, ignore error
-	path := filepath.Join(dataDir, refid+"-"+in.InterfaceName)
-	_ = os.Remove(path)
 	return nil
 }
 

--- a/pkg/netconf/tappodinterface.go
+++ b/pkg/netconf/tappodinterface.go
@@ -213,9 +213,6 @@ func (pi *tapPodInterface) ReleasePodInterface(in *pb.DelRequest) error {
 		return err
 	}
 	pi.pool.Release(conf.InterfaceName)
-	// remove cache, ignore error
-	path := filepath.Join(utilsGetDataDirPath(types.TapInterface), refid+"-"+in.InterfaceName)
-	_ = os.Remove(path)
 	return nil
 }
 


### PR DESCRIPTION
During the cleanup, the infraagent sends requests to clear the rules from the pipeline followed by pod network namespace and other confs cleanup. This works fine in the regular case.

Sometimes, if the CNI Add request fails, the calico sends a CNI Del call to cleanup. As the rules are not programmed in the pipeline, the delete from the the pipeline fails which leaves the cleanup incomplete. To avoid this, remove the pod network namespace first followed by the pipeline rules.