### PR TITLE
Handle panics and sync data to store.

### DIFF
--- a/inframanager/cmd/main.go
+++ b/inframanager/cmd/main.go
@@ -65,10 +65,6 @@ func main() {
 	ctx := context.Background()
 	stopCh := signals.RegisterSignalHandlers()
 
-	store.NewEndPoint()
-	store.NewService()
-	store.NewPolicy()
-
 	if err := api.OpenP4RtC(ctx, 0, 1, stopCh); err != nil {
 		log.Errorf("Failed to open p4 runtime client connection")
 		os.Exit(1)
@@ -117,6 +113,7 @@ func main() {
 		}
 	}
 
+	api.SetHostInterfaceMac()
 	// Starting inframanager gRPC server
 	waitCh := make(chan struct{})
 

--- a/pkg/inframanager/inframanager.go
+++ b/pkg/inframanager/inframanager.go
@@ -128,9 +128,8 @@ func Run(stopCh <-chan struct{}, waitCh chan<- struct{}) {
 	<-stopCh
 
 	manager.stopServer()
-
-	store.RunSyncEndPointInfo()
-	store.RunSyncServiceInfo()
+	store.SyncDB()
 
 	close(waitCh)
+
 }

--- a/pkg/inframanager/store/storesetup.go
+++ b/pkg/inframanager/store/storesetup.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2022 Intel Corporation.  All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License")
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"errors"
+	"net"
+	"os"
+	"path"
+	"sync"
+
+	"github.com/ipdk-io/k8s-infra-offload/pkg/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	StoreSetupFile = path.Join(StorePath, "setup_db.json")
+)
+
+var setupMutex = &sync.Mutex{}
+
+func InitSetupStore(setFwdPipe bool) bool {
+
+	onceSetup.Do(func() {
+		Setup = &SetupData{}
+	})
+
+	flags := os.O_CREATE
+
+	/*
+		Initialize the store to empty while setting the
+		forwarding pipeline. It indicates that the p4-ovs
+		server has just started and pipeline is set.
+		And no stale forwarding rules should exist in the store.
+		Truncate if any entries from previous server runs.
+	*/
+	if setFwdPipe {
+		flags = flags | os.O_TRUNC
+	}
+
+	if _, err := os.Stat(StorePath); errors.Is(err, os.ErrNotExist) {
+		err := os.MkdirAll(StorePath, 0755)
+		if err != nil {
+			log.Errorf("Failed to create directory %s, err: %s", StorePath, err)
+			return false
+		}
+	}
+
+	verifiedFileName, err := utils.VerifiedFilePath(StoreSetupFile, StorePath)
+	if err != nil {
+		log.Errorf("Failed to open %s, error: %s ", StoreSetupFile, err)
+		return false
+	}
+
+	/* Create the store file if it doesn't exist */
+	file, err := NewOpenFile(verifiedFileName, flags, 0755)
+	log.Info("store ep file path:", StoreSetupFile)
+	if err != nil {
+		log.Errorf("Failed to open %s, error: %s", StoreSetupFile, err)
+		return false
+	}
+	file.Close()
+
+	data, err := NewReadFile(StoreSetupFile)
+	if err != nil {
+		log.Errorf("Failed to read %s, error: %s", StoreSetupFile, err)
+		return false
+	}
+
+	if len(data) == 0 {
+		return true
+	}
+
+	err = JsonUnmarshal(data, &Setup)
+	if err != nil {
+		log.Errorf("Failed to unmarshal data from %s, error: %s", StoreSetupFile, err)
+		return false
+	}
+
+	return true
+}
+
+func GetHostInterfaceMac() string {
+	return Setup.HostInterfaceMac
+}
+
+func SetHostInterfaceMac(mac string) bool {
+	if len(mac) == 0 {
+		log.Errorf("Invalid mac address %s", mac)
+		return false
+	}
+	if _, err := net.ParseMAC(mac); err != nil {
+		log.Errorf("Invalid mac address %s", mac)
+		return false
+	}
+
+	setupMutex.Lock()
+	Setup.HostInterfaceMac = mac
+	setupMutex.Unlock()
+
+	return true
+}
+
+func RunSyncSetupInfo() bool {
+	jsonStr, err := JsonMarshalIndent(Setup, "", " ")
+	if err != nil {
+		log.Errorf("Failed to marshal endpoint entries map %s", err)
+		return false
+	}
+
+	if err = NewWriteFile(StoreSetupFile, jsonStr, 0755); err != nil {
+		log.Errorf("Failed to write entries to %s, err %s",
+			StoreSetupFile, err)
+		return false
+	}
+
+	return true
+}

--- a/scripts/dpdk/create_interfaces.sh
+++ b/scripts/dpdk/create_interfaces.sh
@@ -57,7 +57,7 @@ function is_power_of_two () {
 }
 
 function copy_certs() {
-  if [ -d "./scripts/tls/certs/infrap4d/certs" ]; then
+  if [ -d "./scripts/tls/certs/infrap4d" ]; then
     if [ ! -d $STRATUM_DIR ]; then
         echo "stratum directory not found."
         exit 1
@@ -68,7 +68,7 @@ function copy_certs() {
     rm -rf $STRATUM_DIR/certs/client.key
     rm -rf $STRATUM_DIR/certs/stratum.crt
     rm -rf $STRATUM_DIR/certs/stratum.key
-    cp -r ./scripts/tls/certs/infrap4d/certs/* /usr/share/stratum/certs
+    cp -r ./scripts/tls/certs/infrap4d/* /usr/share/stratum/certs
   else
     echo "Missing infrap4d certificates. Run \"make gen-certs\" and try again."
     exit 1


### PR DESCRIPTION
The current implementation with signal handler is failing to handle segmentation faults or any other dumps. To fix this, added changes to safely sync the data to the store and use the same when the pod is restarted.