### PR TITLE
policy support only for dpdk and other fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ datadir=/share/infra/k8s_dp
 bindir=/opt/infra
 sbindir=/sbin/infra
 certdir=/etc/pki
+jsonfiles=/share/infra/jsonfiles
 
 RUNFILES:=$(logdir)/arp-proxy* $(logdir)/infra* $(cnidir)/infra* $(sysconfdir)/config.yaml $(datadir)
 RUNFILES+=$(bindir)/felix-api* $(bindir)/infra* $(bindir)/arp-proxy*
@@ -94,11 +95,13 @@ install:
 	install -d $(DESTDIR)$(datadir)
 	install -d $(DESTDIR)$(bindir)
 	install -d $(DESTDIR)$(sbindir)
+	install -d $(DESTDIR)$(jsonfiles)
 	install -m 0755 bin/* $(DESTDIR)$(bindir)
 	install -C -m 0755 ./deploy/inframanager-config.yaml $(DESTDIR)$(sysconfdir)/inframanager-config.yaml
 	install -C -m 0755 ./deploy/infraagent-config.yaml $(DESTDIR)$(sysconfdir)/infraagent-config.yaml
 	install -C -m 0755 ./scripts/$(tagname)/*.sh $(DESTDIR)$(sbindir)
 	install -C -m 0755 -t $(DESTDIR)$(datadir) ./k8s_dp/$(tagname)/* ./LICENSE
+	install -C -m 0755 ./pkg/inframanager/p4/*.json $(DESTDIR)$(jsonfiles)
 
 test:
 	./hack/cicd/run-tests.sh

--- a/images/Dockerfile.manager
+++ b/images/Dockerfile.manager
@@ -25,8 +25,8 @@ RUN echo ${TAG} ${ARCH} && CGO_ENABLED=0 GOOS=linux GOARCH=$ARCH GO111MODULE=on 
 
 FROM alpine:3.16
 WORKDIR /
-RUN mkdir -p /share/infra/p4files /etc/infra /share/infra/k8s_dp
+RUN mkdir -p /share/infra/jsonfiles /etc/infra /share/infra/k8s_dp
 COPY --from=builder /workspace/bin/inframanager /inframanager
 COPY --from=builder /workspace/k8s_dp /share/infra/k8s_dp/
-COPY --from=builder /workspace/pkg/inframanager/p4/*.json /share/infra/p4files/
+COPY --from=builder /workspace/pkg/inframanager/p4/*.json /share/infra/jsonfiles/
 ENTRYPOINT ["/inframanager"]

--- a/inframanager/api_handler/api_handler.go
+++ b/inframanager/api_handler/api_handler.go
@@ -813,6 +813,14 @@ func (s *ApiServer) ActivePolicyUpdate(ctx context.Context, in *proto.ActivePoli
 
 	logger.Infof("Incoming updatePolicy Request %+v", in)
 
+	/*
+		Currently supporting policies for dpdk target only
+	*/
+
+	if config.InterfaceType != "tap" {
+		return out, nil
+	}
+
 	server := NewApiServer()
 
 	ingress[tcp].RuleGroup.Protocol = p4.PROTO_TCP
@@ -1016,6 +1024,14 @@ func (s *ApiServer) ActivePolicyRemove(ctx context.Context, in *proto.ActivePoli
 
 	logger.Infof("Incoming deletePolicy Request %+v", in)
 
+	/*
+		Currently supporting policies for dpdk target only
+	*/
+
+	if config.InterfaceType != "tap" {
+		return out, nil
+	}
+
 	server := NewApiServer()
 
 	policy := store.Policy{
@@ -1115,6 +1131,14 @@ func (s *ApiServer) UpdateLocalEndpoint(ctx context.Context, in *proto.WorkloadE
 
 	logger.Infof("Incoming UpdateLocalEndpoint Request %+v", in)
 
+	/*
+		Currently supporting policies for dpdk target only
+	*/
+
+	if config.InterfaceType != "tap" {
+		return out, nil
+	}
+
 	if len(in.Endpoint.Ipv4Nets) == 0 {
 		err := errors.New("No IP address assigned for the endpoint")
 		logger.Errorf("No IP addresses assigned for the endpoint")
@@ -1185,6 +1209,14 @@ func (s *ApiServer) RemoveLocalEndpoint(ctx context.Context, in *proto.WorkloadE
 	}
 
 	logger.Infof("Incoming RemoveLocalEndpoint Request %+v", in)
+
+	/*
+		Currently supporting policies for dpdk target only
+	*/
+
+	if config.InterfaceType != "tap" {
+		return out, nil
+	}
 
 	server := NewApiServer()
 

--- a/pkg/inframanager/p4/utils.go
+++ b/pkg/inframanager/p4/utils.go
@@ -78,7 +78,7 @@ var Env string
 var P4w P4RtCWrapper
 
 var (
-	P4FilePath = "/share/infra/p4files/"
+	JsonFilePath = "/share/infra/jsonfiles/"
 )
 
 // Structure reads table details from json file
@@ -95,7 +95,7 @@ type Table struct {
 }
 
 func parseJson(fileName string) map[string][]Table {
-	file := P4FilePath + fileName
+	file := JsonFilePath + fileName
 	fmt.Println(file)
 
 	data, err := os.ReadFile(file)

--- a/pkg/inframanager/store/store_suite_test.go
+++ b/pkg/inframanager/store/store_suite_test.go
@@ -1001,7 +1001,8 @@ var _ = Describe("Storepolicy", func() {
 
 			It("returns false when map is valid and not empty", func() {
 				data_valid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1106,7 +1107,8 @@ var _ = Describe("Storepolicy", func() {
 
 				//WorkerEndPoint
 				data_valid2 := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1169,7 +1171,8 @@ var _ = Describe("Storepolicy", func() {
 
 				//WorkerEndPoint
 				data_valid2 := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.3/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.3",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1392,7 +1395,8 @@ var _ = Describe("Storepolicy", func() {
 			//Valid case 1
 			It("writes the data to the store if data is valid and returns true", func() {
 				data_valid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1402,7 +1406,8 @@ var _ = Describe("Storepolicy", func() {
 			//Invalid case 1
 			It("returns error if WorkerEp is invalid", func() {
 				data_invalid1 := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.a.b/44",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.a.b",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1575,7 +1580,8 @@ var _ = Describe("Storepolicy", func() {
 			//Valid case 1
 			It("Deletes the data from the store and returns true if data is present in the store", func() {
 				data_valid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1586,7 +1592,8 @@ var _ = Describe("Storepolicy", func() {
 			//Invalid case 1
 			It("returns error when data is not present in store", func() {
 				data_invalid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.2/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.2",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1738,7 +1745,8 @@ var _ = Describe("Storepolicy", func() {
 			// Valid case 1
 			It("Gets the data from the store and returns true when input is valid", func() {
 				data_valid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1749,7 +1757,8 @@ var _ = Describe("Storepolicy", func() {
 			//Invalid case 1
 			It("returns nil when data is not present", func() {
 				data_invalid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.2/24",
+					WorkerEp:          "test-pod2",
+					WorkerIp:          "10.10.10.2",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1949,7 +1958,7 @@ var _ = Describe("Storepolicy", func() {
 		})
 	})
 
-	//WorkerEp: UpdateToStore
+	//WorkerIp: UpdateToStore
 	Describe("UpdateToStore", func() {
 
 		Context("updates Policy-WorkerEp data to the store", func() {
@@ -1970,7 +1979,8 @@ var _ = Describe("Storepolicy", func() {
 			//Valid case 1
 			It("returns true if data is valid and update to store succeeds", func() {
 				data_valid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1986,7 +1996,8 @@ var _ = Describe("Storepolicy", func() {
 				// This case is supposed to pass because if
 				// an entry isn't found, it is added instead
 				data_valid1 := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.2/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.2",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -1999,7 +2010,8 @@ var _ = Describe("Storepolicy", func() {
 				// and it returns true if the same data exists
 				// even though no update is actually done.
 				data_valid2 := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}
@@ -2128,7 +2140,7 @@ var _ = Describe("Storepolicy", func() {
 		})
 	})
 
-	//WorkerEp: RunSyncWorkerEpInfo
+	//WorkerIp: RunSyncWorkerEpInfo
 	Describe("RunSyncWorkerEpInfo", func() {
 
 		Context("Writes to persistent storage", func() {
@@ -2144,7 +2156,8 @@ var _ = Describe("Storepolicy", func() {
 				store.StorePath = path.Join(tempDir, "inframanager")
 				store.WorkerepFile = path.Join(store.StorePath, "workerep_db.json")
 				data_valid := store.PolicyWorkerEndPoint{
-					WorkerEp:          "10.10.10.1/24",
+					WorkerEp:          "test-pod",
+					WorkerIp:          "10.10.10.1",
 					PolicyNameIngress: []string{"policy1", "policy2"},
 					PolicyNameEgress:  []string{"policy3", "policy4"},
 				}

--- a/pkg/inframanager/store/storepolicy.go
+++ b/pkg/inframanager/store/storepolicy.go
@@ -209,14 +209,20 @@ func (ipsetadd IpSet) WriteToStore() bool {
 
 func (ep PolicyWorkerEndPoint) WriteToStore() bool {
 
-	ip, ipset, err := net.ParseCIDR(ep.WorkerEp)
-	if err != nil {
-		log.Errorf("Invalid Cidr = %s, ip=%s, ipset=%s", ep.WorkerEp, ip, ipset)
-		return false
-	}
 	if reflect.DeepEqual(ep, PolicyWorkerEndPoint{}) {
 		return false
 	}
+
+	if len(ep.WorkerEp) == 0 {
+		log.Errorf("Invalid endpoint name = %s", ep.WorkerEp)
+		return false
+	}
+
+	if net.ParseIP(ep.WorkerIp) == nil {
+		log.Errorf("Invalid IP = %s", ep.WorkerIp)
+		return false
+	}
+
 	PolicySet.PolicyLock.Lock()
 	PolicySet.WorkerEpMap[ep.WorkerEp] = ep
 	PolicySet.PolicyLock.Unlock()


### PR DESCRIPTION
The changes include
- Copy json files required by the inframanager p4 stitching.
- Add sanity checks to worker endpoint store update.
- Fix worker endpoint wrong sanity check.
- Fix unit tests w.r.t the above changes.