### PR TITLE
Fixed empty host interface, default rule re-insert

### DIFF
--- a/inframanager/api_handler/api_handler.go
+++ b/inframanager/api_handler/api_handler.go
@@ -1426,7 +1426,7 @@ func (s *ApiServer) SetupHostInterface(ctx context.Context, in *proto.SetupHostI
 		logger.Infof("Host Interface ip has changed")
 
 		ep := store.EndPoint{
-			PodIpAddress: ipAddr,
+			PodIpAddress: hostInterface.Ip,
 		}
 
 		entry := ep.GetFromStore()
@@ -1444,7 +1444,7 @@ func (s *ApiServer) SetupHostInterface(ctx context.Context, in *proto.SetupHostI
 		logger.Infof("Host Interface mac has changed")
 
 		ep := store.EndPoint{
-			PodIpAddress: ipAddr,
+			PodIpAddress: hostInterface.Ip,
 		}
 
 		entry := ep.GetFromStore()

--- a/inframanager/cmd/main.go
+++ b/inframanager/cmd/main.go
@@ -113,7 +113,7 @@ func main() {
 		}
 	}
 
-	api.SetHostInterfaceMac()
+	api.SetHostInterface()
 	// Starting inframanager gRPC server
 	waitCh := make(chan struct{})
 

--- a/pkg/inframanager/store/storedefinition.go
+++ b/pkg/inframanager/store/storedefinition.go
@@ -35,8 +35,14 @@ type store interface {
 	UpdateToStore() bool
 }
 
+type Iface struct {
+	Ip  string
+	Mac string
+}
+
 type SetupData struct {
-	HostInterfaceMac string
+	HostInterface  Iface
+	SetDefaultRule bool
 }
 
 type EndPoint struct {

--- a/pkg/inframanager/store/storesetup.go
+++ b/pkg/inframanager/store/storesetup.go
@@ -96,11 +96,11 @@ func InitSetupStore(setFwdPipe bool) bool {
 	return true
 }
 
-func GetHostInterfaceMac() string {
-	return Setup.HostInterfaceMac
+func GetHostInterface() Iface {
+	return Setup.HostInterface
 }
 
-func SetHostInterfaceMac(mac string) bool {
+func SetHostInterface(ip string, mac string) bool {
 	if len(mac) == 0 {
 		log.Errorf("Invalid mac address %s", mac)
 		return false
@@ -110,11 +110,31 @@ func SetHostInterfaceMac(mac string) bool {
 		return false
 	}
 
+	if len(ip) == 0 {
+		log.Errorf("Invalid mac address %s", mac)
+		return false
+	}
+	if net.ParseIP(ip) == nil {
+		log.Errorf("Invalid ip address %s", ip)
+		return false
+	}
+
 	setupMutex.Lock()
-	Setup.HostInterfaceMac = mac
+	Setup.HostInterface.Ip = ip
+	Setup.HostInterface.Mac = mac
 	setupMutex.Unlock()
 
 	return true
+}
+
+func SetDefaultRule() {
+	setupMutex.Lock()
+	Setup.SetDefaultRule = true
+	setupMutex.Unlock()
+}
+
+func IsDefaultRuleSet() bool {
+	return Setup.SetDefaultRule
 }
 
 func RunSyncSetupInfo() bool {


### PR DESCRIPTION
- Added changes to read the host interface when the manager or agent is restarted.
- Added a check to avoid re-insertion of default rule for every manager restart.