### PR TITLE
Potential fix for code scanning alert no. 1: Insecure TLS configuration

### DIFF
--- a/pkg/utils/tls.go
+++ b/pkg/utils/tls.go
@@ -65,8 +65,7 @@ var CipherMap map[string]uint16
 
 func CreateCipherMap() {
 	onceMap.Do(func() {
-		ciphers := tls.CipherSuites()
-		ciphers = append(ciphers, tls.InsecureCipherSuites()...)
+		ciphers := tls.CipherSuites() // Only include secure cipher suites
 		CipherMap = map[string]uint16{}
 
 		for _, c := range ciphers {


### PR DESCRIPTION
Potential fix for [https://github.com/ipdk-io/k8s-infra-offload/security/code-scanning/1](https://github.com/ipdk-io/k8s-infra-offload/security/code-scanning/1)

To ensure that only secure TLS cipher suites can be configured, the program must not allow insecure cipher suites (those from `tls.InsecureCipherSuites()`) to be selectable or present in `CipherMap`. The best way to fix this without changing existing functionality is to modify `CreateCipherMap` so that it only populates `CipherMap` with secure cipher suites, i.e., those from `tls.CipherSuites()` and **not** those from `tls.InsecureCipherSuites()`. The rest of the code (such as cipher suite selection and validation) can remain as-is, since it will now only allow secure cipher suite names/IDs. This change should be made directly in the `CreateCipherMap` function in `pkg/utils/tls.go`.

No additional libraries or external dependencies are needed, as all required functionality is available in the Go standard library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
